### PR TITLE
Find a small to medium bug fix

### DIFF
--- a/js/google-image-helper.js
+++ b/js/google-image-helper.js
@@ -76,7 +76,7 @@ class GoogleItemResult {
 
 class GoogleImageDetails {
     /**
-     * The URL of the page whee the image was found.
+     * The URL of the page where the image was found.
      */
     contextLink
 


### PR DESCRIPTION
Changed 'whee' to 'where' in the contextLink property documentation.